### PR TITLE
Make a rectangle viewport for fragment shader

### DIFF
--- a/glview/raster/include/FrameBufferTexture.h
+++ b/glview/raster/include/FrameBufferTexture.h
@@ -1,0 +1,17 @@
+#ifndef FRAMEBUFFERTEXTURE_H_
+#define FRAMEBUFFERTEXTURE_H_
+
+#include <GL/glew.h>
+
+class FrameBufferTexture {
+ public:
+  FrameBufferTexture(int width, int height);
+  virtual ~FrameBufferTexture();
+  void bind();
+  void resize(int width, int height);
+
+  GLuint frameBuffer;
+  GLuint texture;
+};
+
+#endif  // FRAMEBUFFERTEXTURE_H_

--- a/glview/raster/include/RasterWindow.h
+++ b/glview/raster/include/RasterWindow.h
@@ -1,12 +1,17 @@
 #ifndef RASTERWINDOW_H_
 #define RASTERWINDOW_H_
 
+class FrameBufferTexture;
+
 class RasterWindow {
  public:
   RasterWindow() {}
-  virtual ~RasterWindow(void) {}
+  virtual ~RasterWindow(void);
 
   void start(int argc, char** argv);
+  void resize(int width, int height);
+ private:
+  FrameBufferTexture* frameBufferTexture;
 };
 
 #endif  // RASTERWINDOW_H_

--- a/glview/raster/include/RectangleProgram.h
+++ b/glview/raster/include/RectangleProgram.h
@@ -1,0 +1,20 @@
+#ifndef RECTANGLEPROGRAM_H_
+#define RECTANGLEPROGRAM_H_
+
+#include <GL/glew.h>
+
+class RectangleProgram {
+ public:
+  RectangleProgram();
+  virtual ~RectangleProgram();
+  void draw();
+ private:
+  GLuint program;
+  GLuint vaoHandle;
+  GLuint vboHandles[2];
+  GLuint vertShader;
+  GLuint fragShader;
+  GLuint frameBuffer;
+};
+
+#endif  // RECTANGLEPROGRAM_H_

--- a/glview/raster/include/ScreenProgram.h
+++ b/glview/raster/include/ScreenProgram.h
@@ -1,0 +1,21 @@
+#ifndef SCREENPROGRAM_H_
+#define SCREENPROGRAM_H_
+
+#include <GL/glew.h>
+
+class ScreenProgram {
+ public:
+  ScreenProgram();
+  virtual ~ScreenProgram();
+  void draw();
+ private:
+  GLuint program;
+  GLuint vaoHandle;
+  GLuint vboHandle;
+  GLuint eboHandle;
+  GLuint vertShader;
+  GLuint fragShader;
+  GLuint frameBuffer;
+};
+
+#endif  // SCREENPROGRAM_H_

--- a/glview/raster/src/FrameBufferTexture.cpp
+++ b/glview/raster/src/FrameBufferTexture.cpp
@@ -1,0 +1,34 @@
+#include "FrameBufferTexture.h"
+
+#include <GLFW/glfw3.h>
+#include <stdio.h>
+
+FrameBufferTexture::FrameBufferTexture(int width, int height) {
+  glGenFramebuffers(1, &frameBuffer);
+
+  glGenTextures(1, &texture);
+  glBindTexture(GL_TEXTURE_2D, texture);
+
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB,
+               GL_UNSIGNED_BYTE, NULL);
+
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+}
+
+void FrameBufferTexture::bind() {
+  glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                          GL_TEXTURE_2D, texture, 0);
+}
+
+void FrameBufferTexture::resize(int width, int height) {
+  glBindTexture(GL_TEXTURE_2D, texture);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, NULL);
+}
+
+FrameBufferTexture::~FrameBufferTexture() {
+  glDeleteFramebuffers(1, &frameBuffer);
+  glDeleteTextures(1, &texture);
+}

--- a/glview/raster/src/RasterWindow.cpp
+++ b/glview/raster/src/RasterWindow.cpp
@@ -1,10 +1,16 @@
 #include "RasterWindow.h"
-#include "TriangleProgram.h"
 
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #include <iostream>
+
+#include "FrameBufferTexture.h"
+#include "RectangleProgram.h"
+#include "ScreenProgram.h"
+#include "TriangleProgram.h"
+
+RasterWindow::~RasterWindow() { delete frameBufferTexture; }
 
 void RasterWindow::start(int argc, char** argv) {
   glfwSetErrorCallback([](int error, const char* description) {
@@ -26,13 +32,21 @@ void RasterWindow::start(int argc, char** argv) {
   glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
   glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
-  GLFWwindow* window = glfwCreateWindow(640, 480, "Hello Triangle", NULL, NULL);
+  int width = 800;
+  int height = 600;
+  auto title = "Hello OpenGL";
+  GLFWwindow* window = glfwCreateWindow(width, height, title, NULL, NULL);
   if (!window) {
     fprintf(stderr, "ERROR: could not open window with GLFW3\n");
     glfwTerminate();
     exit(EXIT_FAILURE);
   }
+
   glfwMakeContextCurrent(window);
+  glfwSetWindowUserPointer(window, this);
+  glfwSetFramebufferSizeCallback(window, [](GLFWwindow* window, int w, int h) {
+    static_cast<RasterWindow*>(glfwGetWindowUserPointer(window))->resize(w, h);
+  });
 
   /* start GLEW extension handler */
   glewInit();
@@ -43,43 +57,56 @@ void RasterWindow::start(int argc, char** argv) {
   printf("Renderer: %s\n", renderer);
   printf("OpenGL version supported %s\n", version);
 
-  /*
-   * tell GL to only draw onto a pixel if the shape is closer to the viewer
-   * than anything already drawn at that pixel
-   */
-  glEnable(GL_DEPTH_TEST); /* enable depth-testing */
-  /*
-   * with LESS depth-testing interprets a smaller depth value as meaning
-   * "closer"
-   */
-  glDepthFunc(GL_LESS);
-
   // Create a scope for the programs, they will destructor when the loop exits.
   {
-    TriangleProgram triangleProgram = TriangleProgram();
+    frameBufferTexture = new FrameBufferTexture(width, height);
+    auto rectangleProgram = RectangleProgram();
+    auto triangleProgram = TriangleProgram();
+    auto screenProgram = ScreenProgram();
 
     /*
-    * This loop clears the drawing surface, then draws the geometry described
-    * by the VAO onto the drawing surface. we 'poll events' to see if the window
-    * was closed, etc. finally, we 'swap the buffers' which displays our drawing
-    * surface onto the view area. we use a double-buffering system which means
-    * that we have a 'currently displayed' surface, and 'currently being drawn'
-    * surface. hence the 'swap' idea. in a single-buffering system we would see
-    * stuff being drawn one-after-the-other
-    */
+     * This loop clears the drawing surface, then draws the geometry described
+     * by the VAO onto the drawing surface. we 'poll events' to see if the
+     * window was closed, etc. finally, we 'swap the buffers' which displays our
+     * drawing surface onto the view area. we use a double-buffering system
+     * which means that we have a 'currently displayed' surface, and 'currently
+     * being drawn' surface. hence the 'swap' idea. in a single-buffering system
+     * we would see stuff being drawn one-after-the-other
+     */
     while (!glfwWindowShouldClose(window)) {
-      /* wipe the drawing surface clear */
+      frameBufferTexture->bind();
+      glEnable(GL_DEPTH_TEST);
+      glDepthFunc(GL_LESS);
       glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+      glDisable(GL_BLEND);
       triangleProgram.draw();
 
+      glEnable(GL_BLEND);
+      glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC1_ALPHA);
+      rectangleProgram.draw();
+
+      glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+      glDisable(GL_DEPTH_TEST);
+      glDisable(GL_BLEND);
+
+      glActiveTexture(GL_TEXTURE0);
+      glBindTexture(GL_TEXTURE_2D, frameBufferTexture->texture);
+      screenProgram.draw();
+
       /* update other events like input handling */
-      glfwPollEvents();
       /* put the stuff we've been drawing onto the display */
       glfwSwapBuffers(window);
+      glfwPollEvents();
     }
   }
 
   /* close GL context and any other GLFW resources */
   glfwDestroyWindow(window);
   glfwTerminate();
+}
+
+void RasterWindow::resize(int width, int height) {
+  glViewport(0, 0, width, height);
+  frameBufferTexture->resize(width, height);
 }

--- a/glview/raster/src/RectangleProgram.cpp
+++ b/glview/raster/src/RectangleProgram.cpp
@@ -1,34 +1,40 @@
-#include "TriangleProgram.h"
+#include "RectangleProgram.h"
 #include "Shader.h"
 
 #include <GLFW/glfw3.h>
+#include <stdio.h>
 
-TriangleProgram::TriangleProgram() {
-  /*
-  * geometry to use. these are 3 xyz points (9 floats total) to make a triangle
-  */
+RectangleProgram::RectangleProgram() {
   GLfloat vertices[] = {
-    0.0f, 0.5f, 0.1f,
-    0.5f, -0.5f, 0.1f,
-    -0.5f, -0.5f, 0.1f
+    -0.9f,  0.3f, 0.0f,  // top left
+     0.9f,  0.3f, 0.0f,  // top right
+     0.9f, -0.9f, 0.0f,  // bottom right
+
+     0.9f, -0.9f, 0.0f,  // bottom right
+    -0.9f, -0.9f, 0.0f,  // bottom left
+    -0.9f,  0.3f, 0.0f   // top left
   };
   GLfloat colors[] = {
-    1.0f, 0.0f, 0.0f, 1.f,
-    0.0f, 1.0f, 0.0f, 1.f,
-    0.0f, 0.0f, 1.0f, 1.f
+    1.0f, 0.0f, 0.0f, 0.5,  // top left
+    0.0f, 1.0f, 0.0f, 0.5,  // top right
+    0.0f, 0.0f, 1.0f, 0.5,  // bottom right
+
+    0.0f, 0.0f, 1.0f, 0.5,  // bottom right
+    0.0f, 1.0f, 1.0f, 0.5,  // bottom left
+    1.0f, 0.0f, 0.0f, 0.5   // top left
   };
 
   // Vertex buffer object (VBO). Generate buffers handle's to pass point and
   // color data to the vertex shader.
   glGenBuffers(2, vboHandles);
-  GLuint verticesHandle = vboHandles[0];
+  GLuint pointsHandle = vboHandles[0];
   GLuint colorsHandle = vboHandles[1];
 
   // Bind the points and colors to the handles.
-  glBindBuffer(GL_ARRAY_BUFFER, verticesHandle);
-  glBufferData(GL_ARRAY_BUFFER, 9 * sizeof(GLfloat), vertices, GL_STATIC_DRAW);
+  glBindBuffer(GL_ARRAY_BUFFER, pointsHandle);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
   glBindBuffer(GL_ARRAY_BUFFER, colorsHandle);
-  glBufferData(GL_ARRAY_BUFFER, 9 * sizeof(GLfloat), colors, GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(colors), colors, GL_STATIC_DRAW);
 
   /*
   * Vertex array object (VAO) is a little descriptor that defines which
@@ -42,7 +48,7 @@ TriangleProgram::TriangleProgram() {
   glEnableVertexAttribArray(0);  // Vertex points
   glEnableVertexAttribArray(1);  // Vertex colors
 
-  glBindBuffer(GL_ARRAY_BUFFER, verticesHandle);
+  glBindBuffer(GL_ARRAY_BUFFER, pointsHandle);
   glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, NULL);
 
   glBindBuffer(GL_ARRAY_BUFFER, colorsHandle);
@@ -54,7 +60,7 @@ TriangleProgram::TriangleProgram() {
   * the vertex shader positions each vertex point
   */
   static const char* vert_source = R"(
-    #version 410
+    #version 460
 
     layout (location=0) in vec3 vertexPosition;
     layout (location=1) in vec4 vertexColor;
@@ -71,38 +77,36 @@ TriangleProgram::TriangleProgram() {
   * The fragment shader colours each fragment (pixel-sized area of the triangle)
   */
   const char* frag_source = R"(
-    #version 410
+    #version 460
 
     layout (location=0) in vec4 vColor;
     layout (location=0) out vec4 fragmentColor;
 
     void main () {
-      fragmentColor = vec4(vColor.rgb, 1.0);
+      fragmentColor = vec4(vColor);
     }
   )";
 
-  vertShader = Shader::compileSource(vert_source, GL_VERTEX_SHADER);
-  fragShader = Shader::compileSource(frag_source, GL_FRAGMENT_SHADER);
-
   /* Link the shaders to a program */
   program = glCreateProgram();
+  vertShader = Shader::compileSource(vert_source, GL_VERTEX_SHADER);
+  fragShader = Shader::compileSource(frag_source, GL_FRAGMENT_SHADER);
   glAttachShader(program, vertShader);
   glAttachShader(program, fragShader);
   glLinkProgram(program);
 }
 
-TriangleProgram::~TriangleProgram() {
+RectangleProgram::~RectangleProgram() {
   glDeleteProgram(program);
   glDeleteShader(vertShader);
   glDeleteShader(fragShader);
   glDeleteBuffers(2, &vboHandles[0]);
   glDeleteVertexArrays(1, &vaoHandle);
+  glDeleteFramebuffers(1, &frameBuffer);
 }
 
-void TriangleProgram::draw() {
+void RectangleProgram::draw() {
   glUseProgram(program);
   glBindVertexArray(vaoHandle);
-  /* draw points 0-3 from the currently bound VAO with current in-use shader
-  */
-  glDrawArrays(GL_TRIANGLES, 0, 3);
+  glDrawArrays(GL_TRIANGLES, 0, 6);
 }

--- a/glview/raster/src/ScreenProgram.cpp
+++ b/glview/raster/src/ScreenProgram.cpp
@@ -1,0 +1,109 @@
+#include "ScreenProgram.h"
+
+#include <GLFW/glfw3.h>
+#include <stdio.h>
+
+#include "Shader.h"
+
+ScreenProgram::ScreenProgram() {
+  // Position--|-Colors-----------|-Texture----
+  GLfloat vertices[] = {
+    -1.f,  1.f,  1.0f, 0.0f, 0.0f,  0.0f, 1.0f,  // top left
+     1.f,  1.f,  0.0f, 1.0f, 0.0f,  1.0f, 1.0f,  // top right
+     1.f, -1.f,  0.0f, 0.0f, 1.0f,  1.0f, 0.0f,  // bottom right
+    -1.f, -1.f,  1.0f, 0.0f, 1.0f,  0.0f, 0.0f   // bottom left
+  };
+  GLuint indices[] = {
+    0, 1, 2,
+    2, 3, 0
+  };
+
+  glGenVertexArrays(1, &vaoHandle);
+  glGenBuffers(1, &vboHandle);
+  glGenBuffers(1, &eboHandle);
+
+  glBindVertexArray(vaoHandle);
+  glBindBuffer(GL_ARRAY_BUFFER, vboHandle);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, eboHandle);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices,
+               GL_STATIC_DRAW);
+
+  // Position attribute
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 7 * sizeof(GLfloat), 0);
+  glEnableVertexAttribArray(0);
+  // Color attribute
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 7 * sizeof(GLfloat),
+                        reinterpret_cast<void*>(2 * sizeof(GLfloat)));
+  glEnableVertexAttribArray(1);
+  // Texture coorindate attribute
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 7 * sizeof(GLfloat),
+                        reinterpret_cast<void*>(5 * sizeof(GLfloat)));
+  glEnableVertexAttribArray(2);  // TexCoords
+  glBindVertexArray(0);
+
+  /*
+   * These are the strings of code for the shaders
+   * the vertex shader positions each vertex point
+   */
+  const char* vert_source = R"(
+    #version 460
+
+    layout (location=0) in vec2 aPosition;
+    layout (location=1) in vec3 aColor;
+    layout (location=2) in vec2 aTexCoord;
+
+    layout (location=0) out vec3 vColor;
+    layout (location=1) out vec2 vTexture;
+
+    void main () {
+      gl_Position = vec4(aPosition, 0.0, 1.0);
+      vColor = aColor;
+      vTexture = aTexCoord;
+    };
+  )";
+
+  /*
+   * The fragment shader colours each fragment (pixel-sized area of the
+   * triangle)
+   */
+  const char* frag_source = R"(
+    #version 460
+
+    layout (location=0) out vec4 fragmentColor;
+
+    layout (location=0) in vec3 vColor;
+    layout (location=1) in vec2 vTexture;
+
+    uniform sampler2D uTexture;
+
+    void main () {
+      fragmentColor = texture(uTexture, vTexture);
+    }
+  )";
+
+  /* Link the shaders to a program */
+  program = glCreateProgram();
+  vertShader = Shader::compileSource(vert_source, GL_VERTEX_SHADER);
+  fragShader = Shader::compileSource(frag_source, GL_FRAGMENT_SHADER);
+  glAttachShader(program, vertShader);
+  glAttachShader(program, fragShader);
+  glLinkProgram(program);
+}
+
+ScreenProgram::~ScreenProgram() {
+  glDeleteProgram(program);
+  glDeleteShader(vertShader);
+  glDeleteShader(fragShader);
+  glDeleteBuffers(1, &vboHandle);
+  glDeleteBuffers(1, &eboHandle);
+  glDeleteVertexArrays(1, &vaoHandle);
+  glDeleteFramebuffers(1, &frameBuffer);
+}
+
+void ScreenProgram::draw() {
+  glUseProgram(program);
+  glBindVertexArray(vaoHandle);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, eboHandle);
+  glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+}

--- a/glview/raster/src/Shader.cpp
+++ b/glview/raster/src/Shader.cpp
@@ -53,15 +53,15 @@ GLuint Shader::compileSource(const char* source, const GLuint& shaderType) {
 bool Shader::check(const GLuint& shader) {
   GLint result;
   glGetShaderiv(shader, GL_COMPILE_STATUS, &result);
-  if (GL_FALSE == result) {
+  if (GL_TRUE != result) {
     GLint logLen = 0;
     glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &logLen);
     if (logLen > 0) {
-      char* log = reinterpret_cast<char*>(malloc(logLen));
+      char* log = new char[logLen];
       GLsizei written;
       glGetShaderInfoLog(shader, logLen, &written, log);
       fprintf(stderr, "Shader error log:\n%s\n", log);
-      free(log);
+      delete[] log;
     }
     return false;
   }
@@ -92,7 +92,7 @@ void Shader::printAttributes(GLuint programHandle) {
   glGetProgramiv(programHandle, GL_ACTIVE_ATTRIBUTES, &nAttribs);
   glGetProgramiv(programHandle, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &maxLength);
 
-  GLchar* name = reinterpret_cast<GLchar*>(malloc(maxLength));
+  GLchar* name = new GLchar[maxLength];
 
   GLint written, size, location;
   GLenum type;
@@ -105,7 +105,7 @@ void Shader::printAttributes(GLuint programHandle) {
     printf(" %-5d | %s\n", location, name);
   }
 
-  free(name);
+  delete[] name;
 }
 
 void Shader::printActiveUniformVars(GLuint programHandle) {
@@ -113,7 +113,7 @@ void Shader::printActiveUniformVars(GLuint programHandle) {
   glGetProgramiv(programHandle, GL_ACTIVE_UNIFORM_MAX_LENGTH, &maxLength);
   glGetProgramiv(programHandle, GL_ACTIVE_UNIFORMS, &nUniforms);
 
-  GLchar* name = reinterpret_cast<GLchar*>(malloc(maxLength));
+  GLchar* name = new GLchar[maxLength];
 
   GLint size, location;
   GLsizei written;
@@ -127,5 +127,5 @@ void Shader::printActiveUniformVars(GLuint programHandle) {
     printf(" %-8d | %s\n", location, name);
   }
 
-  free(name);
+  delete[] name;
 }


### PR DESCRIPTION
The image is pretty simple. But I'm learning some details. This creates 2 passes for rendering a scene. 

1. Render a scene to a frame buffer texture (FrameBufferTexture.cpp)
2. Render the frame buffer texture to a rectangle (SceneProgram.cpp)

The second pass, allows me to play with the fragment shader. Considering each pixel in a fragment shader can do ray tracing, seems logical to use depth and stencil buffers to ray trace within a shader.

https://learnopengl.com/Advanced-OpenGL/Framebuffers
https://learnopengl.com/Getting-started/Textures
https://open.gl/textures
https://open.gl/framebuffers
http://www.opengl-tutorial.org/intermediate-tutorials/tutorial-14-render-to-texture/#using-the-rendered-texture 

![image](https://user-images.githubusercontent.com/3021882/157381222-0e38ade5-58b6-4653-8d25-6b8a7367919f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kmadsen/raytracer-cpp/9)
<!-- Reviewable:end -->
