### PR TITLE
Add depth render buffer for post processing

### DIFF
--- a/glview/raster/include/FrameBufferTexture.h
+++ b/glview/raster/include/FrameBufferTexture.h
@@ -11,7 +11,8 @@ class FrameBufferTexture {
   void resize(int width, int height);
 
   GLuint frameBuffer;
-  GLuint texture;
+  GLuint textureColorBuffer;
+  GLuint renderBuffer;
 };
 
 #endif  // FRAMEBUFFERTEXTURE_H_

--- a/glview/raster/include/RasterWindow.h
+++ b/glview/raster/include/RasterWindow.h
@@ -15,7 +15,7 @@ class RasterWindow {
   void resize(int width, int height);
 
  private:
-  FrameBufferTexture* frameBufferTexture;
+  FrameBufferTexture* frameBufferTexture = nullptr;
 };
 
 #endif  // RASTERWINDOW_H_

--- a/glview/raster/src/FrameBufferTexture.cpp
+++ b/glview/raster/src/FrameBufferTexture.cpp
@@ -6,29 +6,42 @@
 FrameBufferTexture::FrameBufferTexture(int width, int height) {
   glGenFramebuffers(1, &frameBuffer);
 
-  glGenTextures(1, &texture);
-  glBindTexture(GL_TEXTURE_2D, texture);
-
+  // Set up color buffer
+  glGenTextures(1, &textureColorBuffer);
+  glBindTexture(GL_TEXTURE_2D, textureColorBuffer);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB,
                GL_UNSIGNED_BYTE, NULL);
-
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+  // Setup render buffer with depth and stencil
+  glGenRenderbuffers(1, &renderBuffer);
+  glBindRenderbuffer(GL_RENDERBUFFER, renderBuffer);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+  glBindRenderbuffer(GL_RENDERBUFFER, 0);
 }
 
 void FrameBufferTexture::bind() {
   glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-                          GL_TEXTURE_2D, texture, 0);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                         textureColorBuffer, 0);
+
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
+                            GL_RENDERBUFFER, renderBuffer);
 }
 
 void FrameBufferTexture::resize(int width, int height) {
-  glBindTexture(GL_TEXTURE_2D, texture);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
+  glBindTexture(GL_TEXTURE_2D, textureColorBuffer);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB,
                GL_UNSIGNED_BYTE, NULL);
+
+  glBindRenderbuffer(GL_RENDERBUFFER, renderBuffer);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+  glBindRenderbuffer(GL_RENDERBUFFER, 0);
 }
 
 FrameBufferTexture::~FrameBufferTexture() {
   glDeleteFramebuffers(1, &frameBuffer);
-  glDeleteTextures(1, &texture);
+  glDeleteTextures(1, &textureColorBuffer);
+  glDeleteRenderbuffers(1, &renderBuffer);
 }

--- a/glview/raster/src/RasterWindow.cpp
+++ b/glview/raster/src/RasterWindow.cpp
@@ -63,23 +63,25 @@ void RasterWindow::start(raster::Scene* scene) {
   {
     frameBufferTexture = new FrameBufferTexture(scene->width, scene->height);
     auto cameraProgram = CameraProgram(scene);
-    // auto screenProgram = ScreenProgram();
+    auto screenProgram = ScreenProgram();
 
     // Start the render loop
     auto fpsLog = FpsConsoleLog();
     while (!glfwWindowShouldClose(window)) {
-      // frameBufferTexture->bind();
-      glEnable(GL_DEPTH_TEST);
+      // First pass
+      frameBufferTexture->bind();
+      glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
       glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+      glEnable(GL_DEPTH_TEST);
       cameraProgram.draw();
 
+      // Second pass
       glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-      // glDisable(GL_DEPTH_TEST);
-
-      // glActiveTexture(GL_TEXTURE0);
-      // glBindTexture(GL_TEXTURE_2D, frameBufferTexture->texture);
-      // screenProgram.draw();
+      glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+      glClear(GL_COLOR_BUFFER_BIT);
+      glDisable(GL_DEPTH_TEST);
+      glBindTexture(GL_TEXTURE_2D, frameBufferTexture->textureColorBuffer);
+      screenProgram.draw();
 
       // Swap buffers and poll input events
       glfwSwapBuffers(window);
@@ -95,5 +97,7 @@ void RasterWindow::start(raster::Scene* scene) {
 
 void RasterWindow::resize(int width, int height) {
   glViewport(0, 0, width, height);
-  frameBufferTexture->resize(width, height);
+  if (frameBufferTexture != nullptr) {
+    frameBufferTexture->resize(width, height);
+  }
 }

--- a/glview/raster/src/ScreenProgram.cpp
+++ b/glview/raster/src/ScreenProgram.cpp
@@ -64,10 +64,9 @@ ScreenProgram::ScreenProgram() {
   )";
 
   /*
-   * The fragment shader colours each fragment (pixel-sized area of the
-   * triangle)
+   * Use this program to blur the scene
    */
-  const char* frag_source = R"(
+  const char* frag_source_blur = R"(
     #version 460
 
     layout (location=0) out vec4 fragmentColor;
@@ -94,10 +93,28 @@ ScreenProgram::ScreenProgram() {
     }
   )";
 
+  /*
+   * Use this program for verifying basic rendering works.
+   */
+  const char* frag_source_noop = R"(
+    #version 460
+
+    layout (location=0) out vec4 fragmentColor;
+
+    layout (location=0) in vec3 vColor;
+    layout (location=1) in vec2 vTexture;
+
+    uniform sampler2D uTexture;
+
+    void main () {
+      fragmentColor = texture(uTexture, vTexture);
+    }
+  )";
+
   /* Link the shaders to a program */
   program = glCreateProgram();
   vertShader = Shader::compileSource(vert_source, GL_VERTEX_SHADER);
-  fragShader = Shader::compileSource(frag_source, GL_FRAGMENT_SHADER);
+  fragShader = Shader::compileSource(frag_source_noop, GL_FRAGMENT_SHADER);
   glAttachShader(program, vertShader);
   glAttachShader(program, fragShader);
   glLinkProgram(program);


### PR DESCRIPTION
I tested my `FrameBufferTexture` with the new triangles to see if it could blur the image. But This is what it looked like, obviously a depth issue.

OpenGL does not attach a depth buffer by default to a frame buffer. Which makes sense. So this is adding that. Now I run a post processing fragment shader on lots of triangles. Blur the bunny for proof (image at the bottom). The stencil bit will also be necessary for ray tracing (whenever i end up incorporating that).

### Before
![image](https://user-images.githubusercontent.com/3021882/159957509-10f5c181-12c6-484b-a0ef-7750e50e873e.png)

### After
![image](https://user-images.githubusercontent.com/3021882/159958093-ae767215-447b-45bd-b436-e5b21a9345d6.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kmadsen/raytracer-cpp/13)
<!-- Reviewable:end -->
